### PR TITLE
Make extra properties on wrapped emitters unenumerable

### DIFF
--- a/listener.js
+++ b/listener.js
@@ -8,6 +8,18 @@ var unwrap  = shimmer.unwrap;
 // dunderscores are boring
 var SYMBOL = 'wrap@before';
 
+// Sets a property on an object, preserving its enumerability.
+// This function assumes that the property is already writable.
+function defineProperty(obj, name, value) {
+  const enumerable = !!obj[name] && obj.propertyIsEnumerable(name);
+  Object.defineProperty(obj, name, {
+    configurable: true,
+    enumerable: enumerable,
+    writable: true,
+    value: value
+  });
+}
+
 function _process(self, listeners) {
   var l = listeners.length;
   for (var p = 0; p < l; p++) {
@@ -133,10 +145,10 @@ module.exports = function wrapEmitter(emitter, onAddListener, onEmit) {
 
   // support multiple onAddListeners
   if (!emitter[SYMBOL]) {
-    emitter[SYMBOL] = onAddListener;
+    defineProperty(emitter, SYMBOL, onAddListener);
   }
   else if (typeof emitter[SYMBOL] === 'function') {
-    emitter[SYMBOL] = [emitter[SYMBOL], onAddListener];
+    defineProperty(emitter, SYMBOL, [emitter[SYMBOL], onAddListener]);
   }
   else if (Array.isArray(emitter[SYMBOL])) {
     emitter[SYMBOL].push(onAddListener);
@@ -148,13 +160,13 @@ module.exports = function wrapEmitter(emitter, onAddListener, onEmit) {
     wrap(emitter, 'on',          adding);
     wrap(emitter, 'emit',        emitting);
 
-    emitter.__unwrap = function () {
+    defineProperty(emitter, '__unwrap', function () {
       unwrap(emitter, 'addListener');
       unwrap(emitter, 'on');
       unwrap(emitter, 'emit');
       delete emitter[SYMBOL];
       delete emitter.__wrapped;
-    };
-    emitter.__wrapped = true;
+    });
+    defineProperty(emitter, '__wrapped', true);
   }
 };

--- a/test/basic.tap.js
+++ b/test/basic.tap.js
@@ -38,12 +38,14 @@ test("bindEmitter", function (t) {
   });
 
   t.test("with all required parameters", function (t) {
-    t.plan(4);
+    t.plan(5);
 
     function nop() {}
     function passthrough(value) { return value; }
 
     var ee = new Emitter();
+    var numPropsBeforeWrap = Object.keys(ee).length;
+
     t.doesNotThrow(
       function () { wrapEmitter(ee, nop, passthrough); },
       "monkeypatches correctly"
@@ -56,6 +58,10 @@ test("bindEmitter", function (t) {
     });
 
     t.doesNotThrow(function () { ee.emit('test', 8); }, "emitting still works");
+
+    var numPropsAfterWrap = Object.keys(ee).length;
+    t.equal(numPropsAfterWrap, numPropsBeforeWrap,
+      'doesn\'t add extra enumerable properties');
   });
 
   t.test("when a listener removes another listener", function (t) {


### PR DESCRIPTION
This PR makes extra properties (dunderscores and `wrap@before`) on wrapped `EventEmitter` objects unenumerable, as they would otherwise show up in, say, `Object.keys(ee)`. This causes `got` to break when used in conjunction with `continuation-local-storage`.

See https://github.com/othiym23/shimmer/pull/9 for additional context. The modified test in this PR doesn't pass without those changes as well.