### PR TITLE
fix: call all onEmit callbacks when wrapped multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Add dynamic instrumentation to emitters
 
-`shimmer` does a bunch of the work necessary to wrap other methods in
-a wrapper you provide:
+`emitter-listener` does a bunch of the work necessary to wrap event emitters
+methods in wrappers you provide:
 
 ```javascript
 var EventEmitter = require('events').EventEmitter;
@@ -34,7 +34,7 @@ not because it seems like fun.
 Wrap an EventEmitter's event listeners. Each listener will be passed to
 `mark` when it is registered with `.addListener()` or `.on()`, and then
 each listener is passed to `prepare` to be wrapped before it's called
-by the `.emit()` call. `wrapListener` deals with the single listener
+by the `.emit()` call. `wrapEmitter` deals with the single listener
 vs array of listeners logic, and also ensures that edge cases like
 `.removeListener()` being called from within an `.emit()` for the same
 event type is handled properly.
@@ -42,3 +42,9 @@ event type is handled properly.
 The wrapped EE can be restored to its pristine state by using
 emitter.__unwrap(), but this should only be used if you *really* know
 what you're doing.
+
+Note: When wrapping the same event emitter multiple times, the provided `mark`
+callbacks will be called in the order in which they have been registered but
+the provided `prepare` callbacks will be called in the reverse order. That is,
+the `prepare` argument given to the last `wrapEmitter` call will be called first
+while the `prepare` given to the first `wrapEmitter` call will be called last.

--- a/test/basic.tap.js
+++ b/test/basic.tap.js
@@ -142,25 +142,33 @@ test("bindEmitter", function (t) {
   });
 
   t.test("when wrapping the same emitter multiple times", function (t) {
-    t.plan(6);
+    t.plan(7);
 
     var ee = new Emitter();
-    var values = [];
+    var onAddListenerCalls = [];
+    var onEmitCalls = [];
     wrapEmitter(
       ee,
-      function marker() { values.push(1); },
-      function passthrough(handler) { return handler; }
+      function onAddListener() { onAddListenerCalls.push(1) },
+      function onEmit(handler) {
+        onEmitCalls.push(1);
+        return handler;
+      }
     );
 
     wrapEmitter(
       ee,
-      function marker() { values.push(2); },
-      function passthrough(handler) { return handler; }
+      function onAddListener() { onAddListenerCalls.push(2) },
+      function onEmit(handler) {
+        onEmitCalls.push(2);
+        return handler;
+      }
     );
 
     ee.on('test', function (value) {
       t.equal(value, 31, "got expected value");
-      t.deepEqual(values, [1, 2], "both marker functions were called");
+      t.deepEqual(onAddListenerCalls, [1, 2], "both onAddListener functions were called");
+      t.deepEqual(onEmitCalls, [2, 1], "both onEmit functions were called");
     });
 
     t.ok(ee.addListener.__wrapped, "addListener is wrapped");


### PR DESCRIPTION
Previously, when wrapping the same emitter multiple times, all
registered `mark` callbacks (aka `onAddListener`) would be called, but only
the `prepare` (aka `onEmit`) callback from the first call to `wrapEmitter`.

This change makes sure that also all registered `prepare`/`onEmit` callbacks
will be called, albeit in the reverse order of how they have been registered.